### PR TITLE
Create ProxySite descriptor.

### DIFF
--- a/statictext/models.py
+++ b/statictext/models.py
@@ -2,7 +2,25 @@ from django.db import models
 from django.contrib.sites.models import Site
 from django.contrib.sites.managers import CurrentSiteManager
 
-__all__ = ["StaticText",]
+__all__ = ["StaticText", "ProxySite",]
+
+
+class ProxySite(object):
+    """
+    Use the ProxySite descriptor to lazy-evaluate site definitions. Useful
+    during testing if the django_site table does not exist.
+    """
+    def __init__(self, **kwargs):
+        try:
+            self.site = Site.objects.get(**kwargs)
+        except:
+            self.site = None
+
+    def __get__(self, object, value):
+        return self.site
+
+    def __set__(self, object, value):
+        raise ValueError("Setting ProxySite after instantiation is not supported.")
 
 
 class StaticText(models.Model):

--- a/statictext/models.py
+++ b/statictext/models.py
@@ -10,16 +10,21 @@ class ProxySite(object):
     Use the ProxySite descriptor to lazy-evaluate site definitions. Useful
     during testing if the django_site table does not exist.
     """
+    _site = None
+
     def __init__(self, **kwargs):
-        try:
-            self.site = Site.objects.get(**kwargs)
-        except:
-            self.site = None
+        self.kwargs = kwargs
 
-    def __get__(self, object, value):
-        return self.site
+    def __get__(self, instance, owner):
+        if not self._site:
+            try:
+                self._site = Site.objects.get(**self.kwargs)
+            except Site.DoesNotExist:
+                pass
 
-    def __set__(self, object, value):
+        return self._site
+
+    def __set__(self, instance, value):
         raise ValueError("Setting ProxySite after instantiation is not supported.")
 
 


### PR DESCRIPTION
This actually came in from a Sentry error today but I'm also running into it. Over the course of getting tests working, I broke the breaking news bars.

Usage:

``` python
class BreakingNews(StaticText):
    proxy_site = ProxySite(name="theatlantic.com")
```
